### PR TITLE
fix(deps): add missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests >= 2.26.0
 lxml >= 4.8.0
+cssselect

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests >= 2.26.0
 lxml >= 4.8.0
-cssselect
+cssselect >= 1.2.0


### PR DESCRIPTION
Hi, found that the used `cssselect` dependency was missing in the requirements.txt. 
 